### PR TITLE
Added utf-8 encoding to file write to address UnicodeEncodeError: on Windws 10.

### DIFF
--- a/timeline.py
+++ b/timeline.py
@@ -197,7 +197,7 @@ def main():
     else:
         queries.append('')
 
-    file = open(filename, file_mode)
+    file = open(filename, file_mode, encoding='utf-8') 
     writer = csv.writer(file)
     writer.writerow(["event_type",
                      "timestamp",


### PR DESCRIPTION
**Issue**
Currently open as: https://github.com/redcanaryco/redcanary-response-utils/issues/10. While running the timeline.py script on a Windows 10 machine, if the logs contain special characters, the script exits with the following message: "UnicodeEncodeError: 'charmap' codec can't encode character '\ufe60' in position 0: character maps to <undefined>".  

**Fix**
The change adds encoding='utf-8' to the file open for Windows 10 compatibility.